### PR TITLE
Update setup.py and fix for backwards compatibility with pip v10.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,13 @@
 
 import os
 from setuptools import find_packages, setup
-from pip.req import parse_requirements
 
 import linkedin2md
 
+def parse_requirements(filename):
+    """ load requirements from a pip requirements file """
+    lineiter = (line.strip() for line in open(filename))
+    return [line for line in lineiter if line and not line.startswith("#")
 
 PROJECT_ROOT_DIR = os.path.dirname(os.path.realpath(__file__))
 install_requirements = parse_requirements(


### PR DESCRIPTION
Fix "Make setup.py use requirements.txt as install_requires" for pip v10.x